### PR TITLE
fix project.yml file bluetooth bug

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -26,6 +26,7 @@ targets:
       ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES
       INFOPLIST_KEY_UILaunchScreen_Generation: YES
       INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+      INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription: "Bluetooth нужен для поиска собеседников и обмена сообщениями поблизости."
       USE_COMPILER_TO_EXTRACT_SWIFT_STRINGS: YES
       SWIFT_EMIT_LOC_STRINGS: YES
       DEVELOPMENT_LANGUAGE: ru


### PR DESCRIPTION
Добавлено описание использования Bluetooth в Info.plist через конфигурацию в project.yml.
Ключ NSBluetoothAlwaysUsageDescription теперь присутствует в финальном .plist-файле приложения.

Начиная с iOS 13, для любого использования Core Bluetooth обязательно наличие строки NSBluetoothAlwaysUsageDescription в Info.plist.
Без этого ключа система может:

1. не доводить CBCentralManager до нормального состояния (оставаться в .unknown или .resetting);
2. не вызывать или вызывать нестабильно метод centralManagerDidUpdateState(_:);
3. не выводить стабильных логов о состоянии Bluetooth (Bluetooth state: …).